### PR TITLE
Add pre-commit & codespell

### DIFF
--- a/.github/workflows/meeting-notes.yml
+++ b/.github/workflows/meeting-notes.yml
@@ -9,11 +9,11 @@ on:
           Common examples are "now", "tomorrow", "next Wednesday", "2023-03-01"...
           See https://www.gnu.org/software/coreutils/manual/html_node/Date-input-formats.html for full details.
         required: false
-        default: "now"
+        default: now
         type: string
   schedule:
     # this is every wednesday, but we want every two! check 'pre-create' job below
-    - cron: "00 12 * * WED"
+    - cron: 00 12 * * WED
   pull_request:
     types:
       - labeled

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,65 @@
+# disable autofixing PRs, commenting "pre-commit.ci autofix" on a pull request triggers a autofix
+ci:
+  autofix_prs: false
+# ignore meeting notes since they are synced as is from HackMD
+exclude: |
+  (?x)^(
+    meetings/archive
+  )/
+repos:
+  # generic verification and formatting
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.6.0
+    hooks:
+      # standard end of line/end of file cleanup
+      - id: mixed-line-ending
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+      # ensure syntaxes are valid
+      - id: check-toml
+      - id: check-yaml
+      # catch git merge/rebase problems
+      - id: check-merge-conflict
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.5.5
+    hooks:
+      # lint & attempt to correct failures (e.g. pyupgrade)
+      - id: ruff
+        args: [--fix]
+      # compatible replacement for black
+      - id: ruff-format
+  - repo: https://github.com/macisamuele/language-formatters-pre-commit-hooks
+    rev: v2.14.0
+    hooks:
+      - id: pretty-format-toml
+        args: [--autofix, --trailing-commas]
+  - repo: https://github.com/jumanjihouse/pre-commit-hook-yamlfmt
+    rev: 0.2.3
+    hooks:
+      - id: yamlfmt
+        # ruamel.yaml doesn't line wrap correctly (?) so set width to 1M to avoid issues
+        args: [--mapping=2, --offset=2, --sequence=4, --width=1000000, --implicit_start]
+  - repo: https://github.com/python-jsonschema/check-jsonschema
+    rev: 0.29.1
+    hooks:
+      # verify github syntaxes
+      - id: check-github-workflows
+  - repo: https://github.com/codespell-project/codespell
+    # see pyproject.toml
+    rev: v2.3.0
+    hooks:
+      - id: codespell
+        args: [--write-changes]
+  - repo: meta
+    # see https://pre-commit.com/#meta-hooks
+    hooks:
+      - id: check-hooks-apply
+      - id: check-useless-excludes
+  - repo: local
+    hooks:
+      - id: git-diff
+        name: git diff
+        entry: git diff --exit-code
+        language: system
+        pass_filenames: false
+        always_run: true

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -180,7 +180,7 @@ The reporting form supports anonymous incident reporting.  Anonymous reporting w
 
 ## Conflicts of Interest
 
-Committee members are expected to recuse themselves if they have a conflict of interest, and are required to recuse themselves if they are the accused or the target of the reported behavior. In addition, the CoC Committee can [vote](#voting-and-decision-making) to remove a committee member from a case, if the committee feels that the member has a conflict of interest.  This [vote](#voting-and-decision-making) requires a simple majority.
+Committee members are expected to recuse themselves if they have a conflict of interest, and are required to recuse themselves if they are the accused or the target of the reported behavior. In addition, the CoC Committee can [vote](#voting-and-decision-making) to remove a committee member from a case, if the committee feels that the member has a conflict of interest.  This [vote](#voting-and-decision-making) requires a simple majority. <!-- codespell:ignore recuse -->
 
 If you are concerned about making a report that will be read by all committee members, you are strongly encouraged to contact [individual committee members](#committee-membership) directly.
 

--- a/LICENSE
+++ b/LICENSE
@@ -393,4 +393,3 @@ the avoidance of doubt, this paragraph does not form part of the
 public licenses.
 
 Creative Commons may be contacted at creativecommons.org.
-

--- a/meetings/agenda_template.md
+++ b/meetings/agenda_template.md
@@ -1,7 +1,7 @@
 ---
 tags: [meeting-notes]
 ---
-# {{ date.strftime("%Y-%m-%d") }} Conda Community Meeting 
+# {{ date.strftime("%Y-%m-%d") }} Conda Community Meeting
 
 [Zoom link](https://zoom.us/j/9138593505?pwd=SWh3dE1IK05LV01Qa0FJZ1ZpMzJLZz09) · [What time is the meeting in my time zone](https://dateful.com/convert/utc?t=5pm)
 
@@ -35,4 +35,3 @@ X people in total
 ## New Agenda Items
 
 - [ ]
-

--- a/pixi.toml
+++ b/pixi.toml
@@ -1,13 +1,13 @@
+[dependencies]
+python = ">=3.12.4,<3.13"
+
 [project]
-name = "governance"
-version = "0.1.0"
-description = "Add a short description here"
 authors = ["Wolf Vollprecht <w.vollprecht@gmail.com>"]
 channels = ["conda-forge"]
+description = "Add a short description here"
+name = "governance"
 platforms = ["osx-arm64"]
+version = "0.1.0"
 
 [tasks]
 vote_markdown = "python to_vote.py"
-
-[dependencies]
-python = ">=3.12.4,<3.13"

--- a/to_vote.py
+++ b/to_vote.py
@@ -2,36 +2,38 @@ import csv
 import io
 from pathlib import Path
 
+
 def csv_to_markdown(csv_data):
     # Create a StringIO object to simulate a file
     csv_file = io.StringIO(csv_data)
-    
+
     # Read the CSV data
     csv_reader = csv.DictReader(csv_file)
-    
+
     # Start the Markdown output
     markdown_output = "# GitHub Users Selection List\n\n"
-    
+
     # Process each row
     for row in csv_reader:
-        github_username = row['github_username']
-        name = row['name']
-        
+        github_username = row["github_username"]
+        name = row["name"]
+
         # Build the Markdown line
         line = f"@{github_username} ({name})\n"
         line += "- [ ]  yes\n"
         line += "- [ ]  no\n"
         line += "- [ ]  abstain\n"
-        
+
         markdown_output += line + "\n"
-    
+
     return markdown_output
+
 
 if __name__ == "__main__":
     # Read the CSV file
     csv_data = Path("steering.csv").read_text()
-    
+
     # Convert the CSV data to Markdown
     markdown_output = csv_to_markdown(csv_data)
-    
+
     print(markdown_output)


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

We wish to copy the entire CoC.md file to other repos in the conda orgs (see https://github.com/conda/governance/pull/146, https://github.com/conda/infrastructure/pull/937, https://github.com/conda/infrastructure/pull/973, https://github.com/conda/infrastructure/pull/975). Unfortunately repos with pre-commit & codespell enabled will falsely correct `recuse` to `recurse`. While this can be ignored downstream, doing so will require special attention in each of the downstream repos.

Instead I propose to enable pre-commit & codespell here and to mark `recuse` as ignored in the CoC.md source.

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
