### PR TITLE
Record PyPI organization scope

### DIFF
--- a/teams/infrastructure.yml
+++ b/teams/infrastructure.yml
@@ -12,6 +12,7 @@ scopes:
   other:
     - https://github.com/conda-bot
     - https://matrix.to/#/!tpEQSUGYWHNdgpDFNc:matrix.org # private
+    - https://pypi.org/org/conda/
 links:
   - https://github.com/conda/governance/issues/84
 members:


### PR DESCRIPTION
### Description

Records the conda PyPI organization as an infrastructure team responsibility.

Supports conda/infrastructure#1185.