### PR TITLE
Improve incubation request form

### DIFF
--- a/.github/ISSUE_TEMPLATE/incubation_request.yml
+++ b/.github/ISSUE_TEMPLATE/incubation_request.yml
@@ -6,15 +6,9 @@ body:
   - type: markdown
     attributes:
       value: |
-        Per the [conda governance policy](https://github.com/conda/governance#incubation),
-        any single Steering Council member may add a project to the incubator, given the
-        knowledge and consent of the author(s).
+        Per the [conda governance policy](https://github.com/conda/governance#incubation), any single Steering Council member may add a project to the incubator, given the knowledge and consent of the author(s).
 
-        The sponsoring Steering Council member is responsible for ensuring that basic legal
-        requirements have been met, including
-        [trademark usage and license terms](https://github.com/conda/governance#trademarks).
-        All conda projects must use an
-        [OSI-approved software license](https://opensource.org/).
+        The sponsoring Steering Council member is responsible for ensuring that basic legal requirements have been met, including [trademark usage and license terms](https://github.com/conda/governance#trademarks). All conda projects must use an [OSI-approved software license](https://opensource.org/).
   - type: input
     id: project_name
     attributes:

--- a/.github/ISSUE_TEMPLATE/incubation_request.yml
+++ b/.github/ISSUE_TEMPLATE/incubation_request.yml
@@ -1,13 +1,11 @@
 name: Request for Incubation
 description: Request to add a project to the conda-incubator organization.
-title: 'Request for incubation: <project name>'
+title: 'Request for incubation: '
 labels: [incubation]
 body:
   - type: markdown
     attributes:
       value: |
-        ## Request for Incubation
-
         Per the [conda governance policy](https://github.com/conda/governance#incubation),
         any single Steering Council member may add a project to the incubator, given the
         knowledge and consent of the author(s).
@@ -46,7 +44,7 @@ body:
       placeholder: e.g. BSD-3-Clause
     validations:
       required: true
-  - type: textarea
+  - type: input
     id: team_members
     attributes:
       label: Initial team members


### PR DESCRIPTION
### Description

Fixes the incubation request form's presentation by allowing the introductory text to wrap naturally, removing the literal project-name text from the prefilled issue title, dropping the repeated heading, and using a single-line field for the initial team members.

Currently:

<img width="1868" height="1810" alt="CleanShot 2026-08-31 at 16 58 14@2x" src="https://github.com/user-attachments/assets/0d217b0a-0594-4674-846e-a91ce085ead6" />
